### PR TITLE
Loop till less or equal than max block number

### DIFF
--- a/src/main/java/org/adridadou/ethereum/ethj/EthereumTest.java
+++ b/src/main/java/org/adridadou/ethereum/ethj/EthereumTest.java
@@ -156,7 +156,7 @@ public class EthereumTest implements EthereumBackend {
 	public List<EventData> logCall(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, SolidityEvent eventDefinition, EthAddress address, String... optionalTopics) {
 		ArrayList events = new ArrayList();
 
-		for (long i = 0; i < this.getCurrentBlockNumber(); i++) {
+		for (long i = 0; i <= this.getCurrentBlockNumber(); i++) {
 			BlockInfo block = this.getBlock(i).get();
 			block.receipts.stream()
 				.filter(params -> address.equals(params.receiveAddress))


### PR DESCRIPTION
Since else the last block number gets skipped. When looping trough arrays looping till < size is standard, but here we actually have block number 2 if getCurrentBlockNumber returns 2. 

Found this when trying to get the test blockchain working again on our project. The last block would always get skipped resulting in lagging 1 event behind.